### PR TITLE
Fix delay queue disc bug

### DIFF
--- a/src/traffic-control/model/delay-queue-disc.cc
+++ b/src/traffic-control/model/delay-queue-disc.cc
@@ -29,7 +29,7 @@ namespace ns3 {
   DelayQueueDisc::GetTypeId (void)
   {
     static TypeId tid = TypeId ("ns3::DelayQueueDisc")
-      .SetParent<Object> ()
+      .SetParent<QueueDisc> ()
       .SetGroupName ("TrafficControl")
       .AddConstructor<DelayQueueDisc> ()
       ;


### PR DESCRIPTION
Hi all,

There seems to be a typo in the `GetTypeId` function of `delay-queue-disc.cc`. It will make users unable to trace `Enqueue`, `Dequeue` this kind of functions if `delay-queue`. 

I encountered this bug and modified that line to fix it :) 

Thanks,
~Vic